### PR TITLE
Small fix: use default template if none given

### DIFF
--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -93,7 +93,7 @@ class Rocco
     defaults = {
       :language      => 'ruby',
       :comment_chars => '#',
-      :template_file => nil
+      :template_file => File.expand_path('../rocco/layout.mustache', __FILE__)
     }
     @options = defaults.merge(options)
 


### PR DESCRIPTION
Hi,

I've added a small fix: when `rocco` was being run without a template option, it would just fail. I think it's reasonable to use the bundled `layout.mustache` in this case.

Best,

Karel
