### PR TITLE
Stop linking to a Raw blob.

### DIFF
--- a/lib/rocco/layout.mustache
+++ b/lib/rocco/layout.mustache
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html;charset=utf-8">
   <title>{{ title }}</title>
-  <link rel="stylesheet" href="http://github.com/jashkenas/docco/raw/0.3.0/resources/docco.css">
+  <link rel="stylesheet" href="http://jashkenas.github.com/docco/resources/docco.css">
 </head>
 <body>
 <div id='container'>


### PR DESCRIPTION
Someone at GitHub told me this wasn't an efficient thing to do.  What if Rocco becomes insanely popular?? (it totally should)
