### PR TITLE
Docblock annotations

### DIFF
--- a/bin/rocco
+++ b/bin/rocco
@@ -8,6 +8,7 @@
 #/                          The string to recognize as a comment marker
 #/   -o, --output=<dir>     Directory where generated HTML files are written
 #/   -t, --template=<path>  The file to use as template when rendering HTML
+#/   -d, --docblocks        Parse Docblock @annotations in comments
 #/       --help             Show this help message
 
 require 'optparse'
@@ -39,6 +40,7 @@ ARGV.options { |o|
   o.on("-l", "--language=LANG") { |lang| options[:language] = lang }
   o.on("-c", "--comment-chars=CHARS") { |chars| options[:comment_chars] = Regexp.escape(chars) }
   o.on("-t", "--template=TEMPLATE") { |template| options[:template_file] = template }
+  o.on("-d", "--docblocks") { options[:docblocks] = true }
   o.on_tail("-h", "--help") { usage($stdout, 0) }
   o.parse!
 } or abort_with_note

--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -368,10 +368,25 @@ class Rocco
     [docs_blocks, code_blocks]
   end
 
+  # Take a list of block comments and convert Docblock @annotations to
+  # Markdown syntax.
+  def docblock(docs)
+    docs.map do |doc|
+      doc.split("\n").map do |line|
+        line.match(/^@\w+/) ? line.sub(/^@(\w+)\s+/, '> **\1** ')+"  " : line
+      end.join("\n")
+    end
+  end
+
   # Take the result of `split` and apply Markdown formatting to comments and
   # syntax highlighting to source code.
   def highlight(blocks)
     docs_blocks, code_blocks = blocks
+
+    # Pre-process Docblock @annotations.
+    if @options[:docblocks]
+      docs_blocks = docblock(docs_blocks)
+    end
 
     # Combine all docs blocks into a single big markdown document with section
     # dividers and run through the Markdown processor. Then split it back out

--- a/test/test_docblock_annotations.rb
+++ b/test/test_docblock_annotations.rb
@@ -1,0 +1,13 @@
+require File.expand_path('../helper', __FILE__)
+
+class RoccoDocblockAnnotationsTest < Test::Unit::TestCase
+  def test_docblock_annotation_conversion
+    r = Rocco.new( 'test', '', { :language => "c", :docblocks => true } ) { "" } # Generate throwaway instance so I can test `parse`
+    assert_equal(
+      [
+        "Comment\n\n> **param** mixed foo  \n> **return** void  "
+      ],
+      r.docblock( ["Comment\n\n@param mixed foo\n@return void"] )
+    )
+  end
+end


### PR DESCRIPTION
Add naïve support for pre-processing Docblock @annotations into Markdown syntax.
