### PR TITLE
Add language support for PHP

### DIFF
--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -238,6 +238,10 @@ class Rocco
       :single => "--",
       :multi => nil
     },
+    "php"          =>  {
+      :single => "//",
+      :multi  => { :start => "/**", :middle => "*", :end => "*/" }
+    },
     "python"        =>  {
       :single => "#",
       :multi  => { :start => '"""', :middle => nil, :end => '"""' }


### PR DESCRIPTION
It seems like there should be a simpler way to map languages to comment styles. Mebbe a shortcut definition for 'c-ish comments'?
