### PR TITLE
added xml comment support

### DIFF
--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -171,7 +171,7 @@ class Rocco
   def detect_language
     @_language ||=
       if pygmentize?
-        %x[pygmentize -N #{@file}].strip!
+        %x[pygmentize -N #{@file}].strip.split('+').first
       else
         "text"
       end
@@ -247,6 +247,10 @@ class Rocco
       :multi  => { :start => '=begin', :middle => nil, :end => '=end' }
     },
     "scheme"        =>  { :single => ";;",  :multi => nil },
+    "xml"           =>  {
+      :single => nil,
+      :multi => { :start => '<!--', :middle => nil, :end => '-->' }
+    },
   }
 
   def generate_comment_chars
@@ -390,7 +394,7 @@ class Rocco
       divider_output = Regexp.new(
         [ "\\n*",
           span,
-          Regexp.escape(front),
+          Regexp.escape(CGI.escapeHTML(front)),
           ' DIVIDER',
           espan,
           "\\n*"
@@ -402,11 +406,11 @@ class Rocco
       divider_input  = "\n\n#{front}\nDIVIDER\n#{back}\n\n"
       divider_output = Regexp.new(
         [ "\\n*",
-          span, Regexp.escape(front), espan,
+          span, Regexp.escape(CGI.escapeHTML(front)), espan,
           "\\n",
           span, "DIVIDER", espan,
           "\\n",
-          span, Regexp.escape(back), espan,
+          span, Regexp.escape(CGI.escapeHTML(back)), espan,
           "\\n*"
         ].join, Regexp::MULTILINE
       )


### PR DESCRIPTION
For enterprisey configuration files.

The main thing is that angle brackets become HTML-escaped after pygmentation.

And I didn't expect pygmentize to return a filetype of `xml+evoque` but it looks like [it does that sort of thing a lot](http://www.danawoodman.com/2009/11/list-of-all-pygments-supported-languages-with-character-codes/), so I split on `+` assuming we don't care about the flavor.
