### PR TITLE
added support for impure block comment styles

### DIFF
--- a/test/test_block_comment_styles.rb
+++ b/test/test_block_comment_styles.rb
@@ -1,0 +1,64 @@
+require File.expand_path('../helper', __FILE__)
+
+class RoccoBlockCommentTest < Test::Unit::TestCase
+  def test_one_liner
+    r = Rocco.new( 'test', '', { :language => "c" } ) { "" } # Generate throwaway instance so I can test `parse`
+    assert_equal(
+      [
+        [ [ "Comment 1" ], [ "def codeblock", "end" ] ]
+      ],
+      r.parse( "/** Comment 1 */\ndef codeblock\nend\n" )
+    )
+  end
+
+  def test_block_start_with_comment
+    r = Rocco.new( 'test', '', { :language => "c" } ) { "" } # Generate throwaway instance so I can test `parse`
+    assert_equal(
+      [
+        [ [ "Comment 1a", "Comment 1b" ], [ "def codeblock", "end" ] ]
+      ],
+      r.parse( "/** Comment 1a\n * Comment 1b\n */\ndef codeblock\nend\n" )
+    )
+  end
+
+  def test_block_end_with_comment
+    r = Rocco.new( 'test', '', { :language => "c" } ) { "" } # Generate throwaway instance so I can test `parse`
+    assert_equal(
+      [
+        [ [ "Comment 1a", "Comment 1b" ], [ "def codeblock", "end" ] ]
+      ],
+      r.parse( "/**\n * Comment 1a\n Comment 1b */\ndef codeblock\nend\n" )
+    )
+  end
+
+  def test_block_end_with_comment_and_middle
+    r = Rocco.new( 'test', '', { :language => "c" } ) { "" } # Generate throwaway instance so I can test `parse`
+    assert_equal(
+      [
+        [ [ "Comment 1a", "Comment 1b" ], [ "def codeblock", "end" ] ]
+      ],
+      r.parse( "/**\n * Comment 1a\n * Comment 1b */\ndef codeblock\nend\n" )
+    )
+  end
+
+  def test_block_start_with_comment_and_end_with_comment
+    r = Rocco.new( 'test', '', { :language => "c" } ) { "" } # Generate throwaway instance so I can test `parse`
+    assert_equal(
+      [
+        [ [ "Comment 1a", "Comment 1b" ], [ "def codeblock", "end" ] ]
+      ],
+      r.parse( "/** Comment 1a\n Comment 1b */\ndef codeblock\nend\n" )
+    )
+  end
+
+  def test_block_start_with_comment_and_end_with_comment_and_middle
+    r = Rocco.new( 'test', '', { :language => "c" } ) { "" } # Generate throwaway instance so I can test `parse`
+    assert_equal(
+      [
+        [ [ "Comment 1a", "Comment 1b" ], [ "def codeblock", "end" ] ]
+      ],
+      r.parse( "/** Comment 1a\n * Comment 1b */\ndef codeblock\nend\n" )
+    )
+  end
+
+end


### PR DESCRIPTION
One-liner blocks:

```
/** comment */
```

Blocks starting with a comment:

```
/** comment
    and so on
 */
```

Blocks ending with a comment:

```
/**
   comment
   and so on */
```

Blocks ending with a comment and having a middle comment character:

```
/**
 * comment
 * and so on */
```

Blocks beginning and ending with a comment:

```
/** comment
    and so on */
```

Blocks beginning and ending with a comment and having a middle comment character:

```
/** comment
 *  and so on */
```
