### PR TITLE
Rake 0.9 Support

### DIFF
--- a/lib/rocco/tasks.rb
+++ b/lib/rocco/tasks.rb
@@ -58,7 +58,7 @@ class Rocco
   # `Rocco::Task.new` takes a task name, the destination directory docs
   # should be built under, and a source file pattern or file list.
   class Task
-    include Rake::DSL
+    include Rake::DSL if defined?(Rake::DSL)
 
     def initialize(task_name, dest='docs/', sources='lib/**/*.rb', options={})
       @name = task_name

--- a/rocco.gemspec
+++ b/rocco.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |s|
   s.test_files = s.files.select {|path| path =~ /^test\/.*_test.rb/}
   s.add_dependency 'rdiscount'
   s.add_dependency 'mustache'
-  s.add_development_dependency 'rake', '>= 0.9.0'
 
   s.has_rdoc = false
   s.homepage = "http://rtomayko.github.com/rocco/"


### PR DESCRIPTION
Rake 0.9 requires classes that define tasks, etc. to include Rake::DSL
