### PR TITLE
Fix for crash when code is nil in lib/rocco/layout.rb, sections method.

### DIFF
--- a/lib/rocco/layout.rb
+++ b/lib/rocco/layout.rb
@@ -18,6 +18,7 @@ class Rocco::Layout < Mustache
   def sections
     num = 0
     @doc.sections.map do |docs,code|
+      code ||= ''
       is_header = /^<h.>(.+)<\/h.>$/.match( docs )
       header_text = is_header && is_header[1].split.join("_")
       num += 1


### PR DESCRIPTION
Rocco crashes when the `code` value is `nil` in the `sections` method contained in `lib/rocco/layout.rb`.  I've implemented the fix for this mentioned in Issue #44, which assigns an empty string to `code` if it is `nil`.  This has fixed the issue and Rocco functions normally now instead of crashing when this case is encountered.
