### PR TITLE
Add `file` tag for Mustache layouts 

### DIFF
--- a/lib/rocco/layout.rb
+++ b/lib/rocco/layout.rb
@@ -15,6 +15,10 @@ class Rocco::Layout < Mustache
     File.basename(@doc.file)
   end
 
+  def file
+    @doc.file
+  end
+
   def sections
     num = 0
     @doc.sections.map do |docs,code|


### PR DESCRIPTION
For when you want to use something more descriptive than `title` in your layout.

---

I just used Rocco to document a CMake build system for one of my projects. Since my commenting style is already pretty close to Markdown, Rocco was able to generate some nice looking docs without much effort on my part.  Thanks for writing this tool!

One thing about CMake is that many files of importance are named `CMakeLists.txt`. Because of this, I wanted a title at the top of my doc pages that was a little more descriptive than that offered by the `title` tag so I could tell if it was the top-level `CMakeLists.txt` I was looking at or `src/CMakeLists.txt`.
