### PR TITLE
Correct path for Rocco::Layout.template_path

### DIFF
--- a/lib/rocco/layout.rb
+++ b/lib/rocco/layout.rb
@@ -2,7 +2,7 @@ require 'mustache'
 require 'pathname'
 
 class Rocco::Layout < Mustache
-  self.template_path = "#{File.dirname(__FILE__)}/.."
+  self.template_path = "#{File.dirname(__FILE__)}/rocco/.."
 
   def initialize(doc, file=nil)
     @doc = doc


### PR DESCRIPTION
Rocco failed for me like this:

```
$ rocco myfile.rb 
rocco: myfile.rb -> myfile.html
/opt/local/lib/ruby/gems/1.8/gems/gems/mustache-0.12.0/lib/mustache.rb:177:in `read': No such file or directory - /opt/local/lib/ruby/gems/1.8/gems/gems/rocco-0.7/lib/layout.mustache (Errno::ENOENT)
```

since the path to the default template is incorrect.
