### PR TITLE
Fix path to docco.css

### DIFF
--- a/lib/rocco/layout.mustache
+++ b/lib/rocco/layout.mustache
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html;charset=utf-8">
   <title>{{ title }}</title>
-  <link rel="stylesheet" href="http://jashkenas.github.com/docco/resources/docco.css">
+  <link rel="stylesheet" href="https://raw.github.com/jashkenas/docco/0.3.0/resources/docco.css">
 </head>
 <body>
 <div id='container'>


### PR DESCRIPTION
GitHub added a 301 redirect to the new raw subdomain, so the CSS doesn't display. See http://steveklabnik.github.com/require_relative/ for example. This fixes it to where the redirect points to.
