### PR TITLE
Uninitialized constant Object::Rocco

### DIFF
--- a/bin/rocco
+++ b/bin/rocco
@@ -13,6 +13,7 @@
 
 require 'optparse'
 require 'fileutils'
+require 'rocco'
 
 # Write usage message to stdout and exit.
 def usage(stream=$stderr, status=1)


### PR DESCRIPTION
I just installed 0.8.1 and I get this error when ever I try to run rocco:

<pre>
$ rocco app/controllers/application_controller.rb 
/Users/clint/Developer/.rvm/gems/ruby-1.9.2-head@rails3/gems/rocco-0.8.1/bin/rocco:66:in `block in <top (required)>': > uninitialized constant Object::Rocco (NameError)
    from /Users/clint/Developer/.rvm/gems/ruby-1.9.2-head@rails3/gems/rocco-0.8.1/bin/rocco:65:in `each'
    from /Users/clint/Developer/.rvm/gems/ruby-1.9.2-head@rails3/gems/rocco-0.8.1/bin/rocco:65:in `<top (required)>'
    from /Users/clint/Developer/.rvm/gems/ruby-1.9.2-head@rails3/bin/rocco:19:in `load'
    from /Users/clint/Developer/.rvm/gems/ruby-1.9.2-head@rails3/bin/rocco:19:in `<main>'
</pre>
