### PR TITLE
Broken Link in README

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,4 @@
 
-
                   ___       ___       ___       ___       ___
                  /\  \     /\  \     /\  \     /\  \     /\  \
                 /::\  \   /::\  \   /::\  \   /::\  \   /::\  \
@@ -13,11 +12,14 @@
     Rocco is  a quick-and-dirty,  literate-programming-style documentation
     generator for Ruby. See the Rocco generated docs for more information:
 
-                    <http://rtomayko.github.com/rocco/>
+            <http://rtomayko.github.com/rocco/rocco.html>
 
+    That page is the result of running Rocco against its own source file:
+
+            <https://github.com/rtomayko/rocco/blob/master/lib/rocco.rb>
 
     Rocco is a port of,  and borrows heavily from, Docco  -- the original
     quick-and-dirty,   hundred-line-long,   literate-programming-style
     documentation generator in CoffeeScript:
 
-                    <http://jashkenas.github.com/docco/>
+            <http://jashkenas.github.com/docco/>


### PR DESCRIPTION
The link to the rendered documentation was broken.  I fixed it, and added a link to the source file that generated it.
