### PR TITLE
Fix broken link in README

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,4 @@
 
-
                   ___       ___       ___       ___       ___
                  /\  \     /\  \     /\  \     /\  \     /\  \
                 /::\  \   /::\  \   /::\  \   /::\  \   /::\  \
@@ -13,7 +12,7 @@
     Rocco is  a quick-and-dirty,  literate-programming-style documentation
     generator for Ruby. See the Rocco generated docs for more information:
 
-                    <http://rtomayko.github.com/rocco/>
+                    <http://rtomayko.github.com/rocco/rocco.html>
 
 
     Rocco is a port of,  and borrows heavily from, Docco  -- the original


### PR DESCRIPTION
The README currently points to http://rtomayko.github.com/rocco/, but this is a broken link. It looks like in the gh-pages branch that index.html contains only the text "rocco.html", which I assume is meant to be pre-processed by something (Jekyll?). That's not happening, and so this leads to a broken link.

My patch changes the README to reference http://rtomayko.github.com/rocco/rocco.html directly. This is a work-around, so if you'd prefer me to fix index.html to redirect properly, just let me know how that is supposed to work.
