### PR TITLE
Add a stylesheet option to build docs using an alternative css stylesheet. 

### DIFF
--- a/bin/rocco
+++ b/bin/rocco
@@ -41,6 +41,7 @@ ARGV.options { |o|
   o.on("-c", "--comment-chars=CHARS") { |chars| options[:comment_chars] = Regexp.escape(chars) }
   o.on("-t", "--template=TEMPLATE") { |template| options[:template_file] = template }
   o.on("-d", "--docblocks") { options[:docblocks] = true }
+  o.on("-s", "--stylesheet=STYLESHEET") { |stylesheet| options[:stylesheet] = stylesheet }
   o.on_tail("-h", "--help") { usage($stdout, 0) }
   o.parse!
 } or abort_with_note

--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -71,6 +71,9 @@ end
 #   when rendering the final, highlighted file via Mustache.  _Defaults
 #   to `nil` (that is, Mustache will use `./lib/rocco/layout.mustache`)_.
 #
+# * `:stylesheet`, which specifies the css stylesheet to use for each
+#   rendered template.  _Defaults to `http://jashkenas.github.com/docco/resources/docco.css`
+#   (the original docco stylesheet)
 class Rocco
   VERSION = '0.8.1'
 
@@ -91,7 +94,8 @@ class Rocco
     defaults = {
       :language      => 'ruby',
       :comment_chars => '#',
-      :template_file => nil
+      :template_file => nil,
+      :stylesheet => 'http://jashkenas.github.com/docco/resources/docco.css'
     }
     @options = defaults.merge(options)
 
@@ -148,7 +152,7 @@ class Rocco
   # Generate HTML output for the entire document.
   require 'rocco/layout'
   def to_html
-    Rocco::Layout.new(self, @options[:template_file]).render
+    Rocco::Layout.new(self, @options[:stylesheet], @options[:template_file]).render
   end
 
   # Helper Functions

--- a/lib/rocco/layout.mustache
+++ b/lib/rocco/layout.mustache
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html;charset=utf-8">
   <title>{{ title }}</title>
-  <link rel="stylesheet" href="http://jashkenas.github.com/docco/resources/docco.css">
+  <link rel="stylesheet" href="{{ stylesheet }}">
 </head>
 <body>
 <div id='container'>

--- a/lib/rocco/layout.rb
+++ b/lib/rocco/layout.rb
@@ -4,8 +4,9 @@ require 'pathname'
 class Rocco::Layout < Mustache
   self.template_path = "#{File.dirname(__FILE__)}/.."
 
-  def initialize(doc, file=nil)
+  def initialize(doc, stylesheet, file=nil)
     @doc = doc
+    @stylesheet = stylesheet
     if not file.nil?
       Rocco::Layout.template_file = file
     end
@@ -13,6 +14,10 @@ class Rocco::Layout < Mustache
 
   def title
     File.basename(@doc.file)
+  end
+
+  def stylesheet
+    @stylesheet
   end
 
   def file

--- a/test/test_stylesheet.rb
+++ b/test/test_stylesheet.rb
@@ -1,0 +1,23 @@
+require File.expand_path('../helper', __FILE__)
+
+class RoccoStylesheetTests < Test::Unit::TestCase
+  def test_default_stylesheet
+    r = Rocco.new( 'file.rb', [ 'file.rb'] ) {
+      "# Content"
+    }
+    html = r.to_html
+    assert(
+      html.include?('<link rel="stylesheet" href="http://jashkenas.github.com/docco/resources/docco.css">')
+    )
+  end
+
+  def test_custom_stylesheet
+    r = Rocco.new( 'file.rb', [ 'file.rb'], :stylesheet => 'http://example.com/custom.css' ) {
+      "# Content"
+    }
+    html = r.to_html
+    assert(
+      html.include?('<link rel="stylesheet" href="http://example.com/custom.css">')
+    )
+  end
+end


### PR DESCRIPTION
Use `rocco -s "http://example.com/style.css"` to use a different stylesheet to the default docco one.
