### PR TITLE
Fix jruby support (fork is not supported on this platform)

### DIFF
--- a/rocco.gemspec
+++ b/rocco.gemspec
@@ -52,8 +52,9 @@ Gem::Specification.new do |s|
   s.executables = ["rocco"]
 
   s.test_files = s.files.select {|path| path =~ /^test\/.*_test.rb/}
-  s.add_dependency 'redcarpet'
+  s.add_dependency 'rdiscount'
   s.add_dependency 'mustache'
+  s.add_dependency 'albino'
 
   s.has_rdoc = false
   s.homepage = "http://rtomayko.github.com/rocco/"


### PR DESCRIPTION
Hi Ryan,

I've tried to fix the jruby support by using [Albino](https://github.com/github/albino) instead of using local fork to run Pygments. This version passes all the tests on MRI 1.8, all the tests on jruby in 1.8 mode and most of the test on jruby in 1.9 mode. Unfortunately, UTF-8 test is broken. The Albino is using 'posix-spawn' gem to start local Pygments, but the posix-spawn doesn't support any other encoding beside BINARY, actually your issue [4](https://github.com/rtomayko/posix-spawn/issues/4).

The second issue I came across is that the test suite is not running clean with 'redcarpet' but it runs just fine with 'rdiscount'. I've changed gem dependency as well.

So, this pull request in not 100% clean for jruby support, but it may give you some ideas. Actually, it seems like changing Albino to support web service pygments and just calling Albino could be interesting approach.

Cheers,
Maksym.
