### PR TITLE
Allow rocco to find pygmentize on Windows

### DIFF
--- a/bin/rocco
+++ b/bin/rocco
@@ -47,8 +47,18 @@ ARGV.options { |o|
   o.parse!
 } or abort_with_note
 
+if RUBY_PLATFORM =~ /(win|w)32$/
+  # windows machine
+  path_dirs = ENV['PATH'].split(';')
+  found_pygmentize = path_dirs.any? { |dir| File.executable?("#{dir}/pygmentize.exe") }
+else
+  # *nix system
+  path_dirs = ENV['PATH'].split(':')
+  found_pygmentize = path_dirs.any? { |dir| File.executable?("#{dir}/pygmentize") }
+end
+
 # Use http://pygments.appspot.com in case `pygmentize(1)` isn't available.
-if ! ENV['PATH'].split(':').any? { |dir| File.exist?("#{dir}/pygmentize") }
+if !found_pygmentize
   unless options[:webservice]
     $stderr.puts "pygmentize not in PATH; using pygments.appspot.com instead"
     options[:webservice] = true

--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -51,7 +51,17 @@ require 'net/http'
 
 # Code is run through [Pygments](http://pygments.org/) for syntax
 # highlighting. If it's not installed, locally, use a webservice.
-if !ENV['PATH'].split(':').any? { |dir| File.executable?("#{dir}/pygmentize") }
+if RUBY_PLATFORM =~ /(win|w)32$/
+  # windows machine
+  path_dirs = ENV['PATH'].split(';')
+  found_pygmentize = path_dirs.any? { |dir| File.executable?("#{dir}/pygmentize.exe") }
+else
+  # *nix system
+  path_dirs = ENV['PATH'].split(':')
+  found_pygmentize = path_dirs.any? { |dir| File.executable?("#{dir}/pygmentize") }
+end
+
+if !found_pygmentize
   warn "WARNING: Pygments not found. Using webservice."
 end
 


### PR DESCRIPTION
If you're using Windows, rocco can't find pygmentize because of the file extension, and because of the delimiter used to separate paths inside the $PATH variable.

This fix should work on Windows, cygwin, and mingw.
