### PR TITLE
Moving version to it's own file, bumping to 1.0.0

### DIFF
--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -75,7 +75,6 @@ end
 #   rendered template.  _Defaults to `http://jashkenas.github.com/docco/resources/docco.css`
 #   (the original docco stylesheet)
 class Rocco
-  VERSION = '0.8.2'
 
   def initialize(filename, sources=[], options={})
     @file       = filename

--- a/lib/rocco/version.rb
+++ b/lib/rocco/version.rb
@@ -1,0 +1,3 @@
+class Rocco
+  VERSION = "1.0.0"
+end


### PR DESCRIPTION
- Moving the version file to lib/rocco/version.rb
- Bumping to 1.0.0, as the API is established with 8,979 total downloads.
