### PR TITLE
Instead of a slow iteration, just using the which binary

### DIFF
--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -51,7 +51,7 @@ require 'net/http'
 
 # Code is run through [Pygments](http://pygments.org/) for syntax
 # highlighting. If it's not installed, locally, use a webservice.
-unless ENV['PATH'].split(':').any? { |dir| File.executable?("#{dir}/pygmentize") }
+if `which pygmentize`.include? "not found"
   warn "WARNING: Pygments not found. Using webservice."
 end
 
@@ -150,8 +150,7 @@ class Rocco
 
   # Returns `true` if `pygmentize` is available locally, `false` otherwise.
   def pygmentize?
-    @_pygmentize ||= ENV['PATH'].split(':').
-      any? { |dir| File.executable?("#{dir}/pygmentize") }
+    @_pygmentize ||= `which pygmentize`
   end
 
   # If `pygmentize` is available, we can use it to autodetect a file's


### PR DESCRIPTION
Switched out a call that iterated over all binaries to a simple call to the system `which` binary.

This might not work on some operating systems.
