### PR TITLE
Adds SQL support to the comment styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+
+.DS_Store

--- a/lib/rocco/comment_styles.rb
+++ b/lib/rocco/comment_styles.rb
@@ -46,6 +46,11 @@ class Rocco
       },
       "scala"         =>  C_STYLE_COMMENTS,
       "scheme"        =>  { :single => ";;",  :multi => nil, :heredoc => nil },
+      "sql"           =>  {
+        :single => nil,
+        :multi => { :start => '/*', :middle => nil, :end => '*/' },
+        :heredoc => nil
+      },
       "xml"           =>  {
         :single => nil,
         :multi => { :start => '<!--', :middle => nil, :end => '-->' },

--- a/lib/rocco/layout.mustache
+++ b/lib/rocco/layout.mustache
@@ -23,8 +23,7 @@
   <table cellspacing=0 cellpadding=0>
   <thead>
     <tr>
-      <th class=docs><h1>{{ title }}</h1></th>
-      <th class=code></th>
+      <th class=docs COLSPAN=2><h1>{{ title }}</h1></th>
     </tr>
   </thead>
   <tbody>

--- a/test/test_language_detection.rb
+++ b/test/test_language_detection.rb
@@ -8,6 +8,14 @@ class RoccoLanguageDetection < Test::Unit::TestCase
       assert_equal "python", r.options[:language], "`@options[:language]` should be set to the correct language"
     end
   end
+  
+  def test_sql_detection
+    r = Rocco.new( 'filename.sql' ) { "" }
+    if r.pygmentize?
+      assert_equal "sql", r.detect_language(), "`detect_language()` should return the correct language"
+      assert_equal "sql", r.options[:language], "`@options[:language]` should be set to the correct language"
+    end
+  end
 
   def test_fallback_default
     r = Rocco.new( 'filename.an_extension_with_no_meaning_whatsoever' ) { "" }


### PR DESCRIPTION
I left out single line SQL comments so that I can comment stuff out without making it all documentation.
