### PR TITLE
Demonstrating failing test for issue 93

### DIFF
--- a/test/fixtures/issue93.js
+++ b/test/fixtures/issue93.js
@@ -1,0 +1,17 @@
+// # Markdown <ul>:
+//
+// * is a bullet 1
+// * is a bullet 2
+function foo() {
+}
+
+/*
+
+# Markdown <ul>:
+
+* should be a bullet 1
+* should be a bullet 2
+
+*/
+function foo() {
+}

--- a/test/test_reported_issues.rb
+++ b/test/test_reported_issues.rb
@@ -83,4 +83,22 @@ class RoccoIssueTests < Test::Unit::TestCase
     )
     assert_equal("<h2>Comment 1</h2>\n", r.sections[0][0])
   end
+
+  def test_issue93_markdown_bullets_squashed
+    # A 'C-style' multi-line comment with a Markdown bulleted list is not turned into a <ul>
+    # http://github.com/rtomayko/rocco/issues/93
+
+    r = Rocco.new( File.dirname(__FILE__) + "/fixtures/issue93.js" )
+    html = r.to_html
+
+    puts html
+    assert(
+      html.match(/<ul>\s*<li>is a bullet 1<\/li>/),
+      "Unordered lists in C-style single-line comments should turn into <ul>"
+    )
+    assert(
+      html.match(/<ul>\s*<li>should be a bullet 1<\/li>/),
+      "Unordered lists in C-style multi-line comments should turn into <ul>"
+    )
+  end
 end


### PR DESCRIPTION
Rocco is useful for docs for languages other than Ruby. Here's a case where JS files, using C-style comments, aren't optimal.

The workaround is single-line comments for lines that need &lt;ul&gt;'s. I spent a little time trying to fix this and failed. Here's a failing test if you think this is a priority.
