### PR TITLE
Support for redcarpet 2.2+ and kramdown

### DIFF
--- a/bin/rocco
+++ b/bin/rocco
@@ -10,7 +10,7 @@
 #/   -t, --template=<path>  The file to use as template when rendering HTML
 #/   -d, --docblocks        Parse Docblock @annotations in comments
 #/       --help             Show this help message
-
+require 'rubygems'
 require 'optparse'
 require 'fileutils'
 require 'rocco'

--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -33,6 +33,38 @@
 
 # We'll need a Markdown library. Try to load one if not already established.
 unless defined?(Markdown)
+  begin
+    require 'redcarpet'
+
+    class Markdown
+      @@markdown = Redcarpet::Markdown.new(Redcarpet::Render::SmartyHTML, :fenced_code_blocks => true)
+
+      def initialize(text, *rest)
+        @text = text
+      end
+
+      def to_html
+        @@markdown.render(@text)
+      end
+    end
+  rescue LoadError, NameError
+  end
+end
+
+unless defined?(Markdown)
+  begin
+    require 'kramdown'
+
+    class Markdown < Kramdown::Document
+      def initialize(text, *rest)
+        super text, :auto_ids => false
+      end
+    end
+  rescue LoadError
+  end
+end
+
+unless defined?(Markdown)
   markdown_libraries = %w[redcarpet rdiscount bluecloth]
   begin
     require markdown_libraries.shift

--- a/rocco.gemspec
+++ b/rocco.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.name = 'rocco'
   s.version = '0.8.2'
-  s.date = '2011-08-27'
+  s.date = '2013-01-23'
 
   s.description = "Docco in Ruby"
   s.summary     = s.description
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.files = %w[
     CHANGES.md
     COPYING
+    Gemfile
     README
     Rakefile
     bin/rocco
@@ -46,13 +47,14 @@ Gem::Specification.new do |s|
     test/test_reported_issues.rb
     test/test_skippable_lines.rb
     test/test_source_list.rb
+    test/test_stylesheet.rb
   ]
   # = MANIFEST =
 
   s.executables = ["rocco"]
 
   s.test_files = s.files.select {|path| path =~ /^test\/.*_test.rb/}
-  s.add_dependency 'redcarpet', '~> 1.17'
+  s.add_dependency 'redcarpet'
   s.add_dependency 'mustache'
 
   s.has_rdoc = false


### PR DESCRIPTION
- Added support for redcarpet 2.2 (changed the API breaking `process_markdown`)
- Added support for kramdown
