### PR TITLE
Update the docco.css URL

### DIFF
--- a/lib/rocco.rb
+++ b/lib/rocco.rb
@@ -90,7 +90,7 @@ class Rocco
       :language      => 'ruby',
       :comment_chars => '#',
       :template_file => nil,
-      :stylesheet    => 'http://jashkenas.github.com/docco/resources/docco.css'
+      :stylesheet    => 'http://jashkenas.github.io/docco/resources/linear/docco.css'
     }.merge(options)
 
     # If we detect a language


### PR DESCRIPTION
For some reason, the '/linear' path was added and the old file is no longer accessible.  Also, github.io to not have the 302.
